### PR TITLE
Control url fix

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,5 +4,5 @@
   "documentation": "",
   "dependencies": [],
   "codeowners": [],
-  "requirements": []
+  "requirements": ["xmltodict==0.12.0"]
 }

--- a/skyq/sky_remote.py
+++ b/skyq/sky_remote.py
@@ -64,9 +64,12 @@ class SkyRemote:
         self._host=host
         self._port=port
         self._jsonport = jsonport
-        self._soapControlURl = self._getSoapControlURL(0)
-        if (self._soapControlURl is None):
-            self._soapControlURl = self._getSoapControlURL(1)
+
+        url_index = 0
+        self._soapControlURl = None
+        while self._soapControlURl is None and url_index < 3:
+            self._soapControlURl = self._getSoapControlURL(url_index)
+            url_index += 1
 
     def http_json(self, path, headers=None) -> str:
         try:


### PR DESCRIPTION
I wasn't getting any results back, and it seemed to be down to the info being on `/description2.xml` for my box... and we were only trying 0 and 1 so far, so I added a loop to go through 0, 1 and 2 to hopefully find the right one.

I also added the xmltodict requirement to the manifest, as I had to install it manually and this way it should be pulled in automatically. Happy to move that to another PR if you would prefer.